### PR TITLE
Add simple support for query params

### DIFF
--- a/src/main/scala/io/github/mkotsur/firebase/rest/FirebaseClient.scala
+++ b/src/main/scala/io/github/mkotsur/firebase/rest/FirebaseClient.scala
@@ -11,7 +11,7 @@ import io.github.mkotsur.firebase.rest.FirebaseClient.FirebaseClientException
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
-import scalaj.http.{Http, HttpRequest}
+import scalaj.http.Http
 
 object FirebaseClient {
 
@@ -34,9 +34,12 @@ class FirebaseClient(val projectId: String) {
 
   private val baseUrl = s"https://$projectId.firebaseio.com"
 
-  def get[T](path: String)
+  def get[T](path: String, options: QueryParams = QueryParams.empty)
             (implicit decoder: Decoder[T], token: AccessToken, ec: ExecutionContext): Future[Option[T]] = Future {
-    Http(s"$baseUrl/$path.json").param("access_token", token.value).asString
+    val basePath = s"$baseUrl/$path.json"
+    val fullPath = s"""$basePath${options.toStringParam}"""
+
+    Http(fullPath).param("access_token", token.value).asString
   } flatMap { response =>
     decode[Option[T]](response.body) match {
       case Right(v) => Future.successful(v)

--- a/src/main/scala/io/github/mkotsur/firebase/rest/QueryParam.scala
+++ b/src/main/scala/io/github/mkotsur/firebase/rest/QueryParam.scala
@@ -1,0 +1,36 @@
+package io.github.mkotsur.firebase.rest
+
+sealed trait QueryParam {
+  def toStringParam: String
+}
+trait QueryParams extends QueryParam {
+  def params: List[QueryParam]
+  override def toStringParam = {
+    params.foldLeft("?"){ (one: String, two: QueryParam) =>
+      one + two.toStringParam + "&"
+    }.dropRight(1)
+  }
+}
+object QueryParams {
+  val empty = new QueryParams{
+    val params = List.empty
+  }
+}
+case class OrderBy(field: String) extends QueryParam {
+  val toStringParam = s"""orderBy="$field""""
+}
+case object OrderByKey extends QueryParam {
+ val toStringParam = s"""orderBy="$$key""""
+}
+case object OrderByValue extends QueryParam {
+  val toStringParam = s"""orderBy="$$value""""
+}
+case class StartAt(value: String) extends QueryParam {
+  val toStringParam = s"""startAt="$value""""
+}
+case class EndAt(value: String) extends QueryParam {
+  val toStringParam = s"""endAt="$value""""
+}
+case class Range(orderField: String, start: String, end: String) extends QueryParams {
+  val params = List(OrderBy(orderField), StartAt(start), EndAt(end))
+}

--- a/src/test/scala/io/github/mkotsur/firebase/rest/FirebaseClientTest.scala
+++ b/src/test/scala/io/github/mkotsur/firebase/rest/FirebaseClientTest.scala
@@ -73,82 +73,97 @@ class FirebaseClientTest extends FunSpec with Matchers with ScalaFutures with Tr
         fc.get[MyUser]("eternal/doesNotExist").futureValue shouldBe None
       }
 
-    }
+      describe("filtering") {
+        it("should return a filtered map of users") {
+          case class MyUser(name: String, age: Int)
 
-    describe("create and remove") {
-      it("should create primitives in Firebase") {
-        val adminCredential = AdminCredentials(validJsonKey)
-        implicit val token = FirebaseClient.getToken(adminCredential).success.value
-        val fc = new FirebaseClient(projectId)
-        fc.put(42, "temp/answer").futureValue shouldBe Some(42)
-        fc.get[Int]("temp/answer").futureValue shouldBe Some(42)
-        fc.delete("temp").futureValue shouldBe((): Unit)
-        fc.get[Int]("temp/answer").futureValue shouldBe None
+          val adminCredential = AdminCredentials(validJsonKey)
+          implicit val token = FirebaseClient.getToken(adminCredential).success.value
+          val fc = new FirebaseClient(projectId)
+
+          val expected = Map(
+            "user1" -> MyUser("John", 42),
+            "user3" -> MyUser("Andre", 60)
+          )
+          val range = Range("name", "A", "K")
+          fc.get[Map[String, MyUser]]("filtering/map", range).futureValue shouldBe Some(expected)
+        }
       }
 
-      it("should create objects in Firebase") {
-        case class MyCow(name: String)
+      describe("create and remove") {
+        it("should create primitives in Firebase") {
+          val adminCredential = AdminCredentials(validJsonKey)
+          implicit val token = FirebaseClient.getToken(adminCredential).success.value
+          val fc = new FirebaseClient(projectId)
+          fc.put(42, "temp/answer").futureValue shouldBe Some(42)
+          fc.get[Int]("temp/answer").futureValue shouldBe Some(42)
+          fc.delete("temp").futureValue shouldBe ((): Unit)
+          fc.get[Int]("temp/answer").futureValue shouldBe None
+        }
 
-        val adminCredential = AdminCredentials(validJsonKey)
-        implicit val token = FirebaseClient.getToken(adminCredential).success.value
-        val fc = new FirebaseClient(projectId)
-        fc.put(MyCow("Henrietta"), "temp/cow").futureValue shouldBe Some(MyCow("Henrietta"))
-        fc.get[MyCow]("temp/cow").futureValue shouldBe Some(MyCow("Henrietta"))
+        it("should create objects in Firebase") {
+          case class MyCow(name: String)
 
-        fc.delete("temp").futureValue shouldBe((): Unit)
-        fc.get[MyCow]("temp/cow").futureValue shouldBe None
-      }
-    }
+          val adminCredential = AdminCredentials(validJsonKey)
+          implicit val token = FirebaseClient.getToken(adminCredential).success.value
+          val fc = new FirebaseClient(projectId)
+          fc.put(MyCow("Henrietta"), "temp/cow").futureValue shouldBe Some(MyCow("Henrietta"))
+          fc.get[MyCow]("temp/cow").futureValue shouldBe Some(MyCow("Henrietta"))
 
-    describe("update") {
-      it("should update values in Firebase") {
-        val adminCredential = AdminCredentials(validJsonKey)
-        implicit val token = FirebaseClient.getToken(adminCredential).success.value
-        val fc = new FirebaseClient(projectId)
-        fc.put("First", "temp/something").futureValue shouldBe Some("First")
-        fc.get[String]("temp/something").futureValue shouldBe Some("First")
-
-        fc.patch[Map[String, Int]](Map("something" -> 43), "temp/").futureValue shouldBe Map("something" -> 43)
-        fc.get[Int]("temp/something").futureValue shouldBe Some(43)
-        fc.delete("temp").futureValue shouldBe((): Unit)
+          fc.delete("temp").futureValue shouldBe ((): Unit)
+          fc.get[MyCow]("temp/cow").futureValue shouldBe None
+        }
       }
 
-      it("should push values into Firebase") {
-        val adminCredential = AdminCredentials(validJsonKey)
-        implicit val token = FirebaseClient.getToken(adminCredential).success.value
-        val fc = new FirebaseClient(projectId)
-        val pushedChildName = fc.post[Int](43, "temp/pushed").futureValue
-        pushedChildName should not be empty
+      describe("update") {
+        it("should update values in Firebase") {
+          val adminCredential = AdminCredentials(validJsonKey)
+          implicit val token = FirebaseClient.getToken(adminCredential).success.value
+          val fc = new FirebaseClient(projectId)
+          fc.put("First", "temp/something").futureValue shouldBe Some("First")
+          fc.get[String]("temp/something").futureValue shouldBe Some("First")
 
-        fc.get[Int](s"temp/pushed/$pushedChildName").futureValue shouldBe Some(43)
-        fc.delete("temp").futureValue shouldBe((): Unit)
-      }
-    }
+          fc.patch[Map[String, Int]](Map("something" -> 43), "temp/").futureValue shouldBe Map("something" -> 43)
+          fc.get[Int]("temp/something").futureValue shouldBe Some(43)
+          fc.delete("temp").futureValue shouldBe ((): Unit)
+        }
 
-    describe("exists") {
-      it("should return false if the path does not exist in the DB") {
-        val adminCredential = AdminCredentials(validJsonKey)
-        implicit val token = FirebaseClient.getToken(adminCredential).success.value
-        val fc = new FirebaseClient(projectId)
+        it("should push values into Firebase") {
+          val adminCredential = AdminCredentials(validJsonKey)
+          implicit val token = FirebaseClient.getToken(adminCredential).success.value
+          val fc = new FirebaseClient(projectId)
+          val pushedChildName = fc.post[Int](43, "temp/pushed").futureValue
+          pushedChildName should not be empty
 
-        fc.exists("/does-not-exist").futureValue shouldBe false
-        fc.exists("does-not-exist").futureValue shouldBe false
-        fc.exists("/does-not-exist/a/b/c").futureValue shouldBe false
-        fc.exists("does-not-exist/a/b/c").futureValue shouldBe false
-
-        fc.exists("eternal/shouldReadThis/a/b/c").futureValue shouldBe false
-        fc.exists("/eternal/shouldReadThis/a/b/c").futureValue shouldBe false
+          fc.get[Int](s"temp/pushed/$pushedChildName").futureValue shouldBe Some(43)
+          fc.delete("temp").futureValue shouldBe ((): Unit)
+        }
       }
 
-      it("should return true if the path exists in the DB") {
-        val adminCredential = AdminCredentials(validJsonKey)
-        implicit val token = FirebaseClient.getToken(adminCredential).success.value
-        val fc = new FirebaseClient(projectId)
+      describe("exists") {
+        it("should return false if the path does not exist in the DB") {
+          val adminCredential = AdminCredentials(validJsonKey)
+          implicit val token = FirebaseClient.getToken(adminCredential).success.value
+          val fc = new FirebaseClient(projectId)
 
-        fc.exists("eternal/shouldReadThis").futureValue shouldBe true
-        fc.exists("/eternal/shouldReadThis").futureValue shouldBe true
+          fc.exists("/does-not-exist").futureValue shouldBe false
+          fc.exists("does-not-exist").futureValue shouldBe false
+          fc.exists("/does-not-exist/a/b/c").futureValue shouldBe false
+          fc.exists("does-not-exist/a/b/c").futureValue shouldBe false
+
+          fc.exists("eternal/shouldReadThis/a/b/c").futureValue shouldBe false
+          fc.exists("/eternal/shouldReadThis/a/b/c").futureValue shouldBe false
+        }
+
+        it("should return true if the path exists in the DB") {
+          val adminCredential = AdminCredentials(validJsonKey)
+          implicit val token = FirebaseClient.getToken(adminCredential).success.value
+          val fc = new FirebaseClient(projectId)
+
+          fc.exists("eternal/shouldReadThis").futureValue shouldBe true
+          fc.exists("/eternal/shouldReadThis").futureValue shouldBe true
+        }
       }
     }
   }
-
 }


### PR DESCRIPTION
This adds simple support for query params, and a test case with filtering maps of objects.

This PR does not include full support to deal with filtered arrays because of we still need to take care of how to read and write arrays. 

For example, trying to get a `List[User]` seems to work with unfiltered requests because firebase returns a json `[]`; but when including filtering query params, firebase gives us a json `{}` on the reply.